### PR TITLE
refactor: adapt to the new template, add ci+cd

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,0 +1,19 @@
+name: CD
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  push-hub:
+    runs-on: ubuntu-latest
+    container:
+      image: jinaai/jina:master-standard
+      options: "--entrypoint /bin/bash"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - id: push
+        run: jina hub push --force ${{ secrets.HUBBLE_UUID }} --secret ${{ secrets.HUBBLE_SECRET }} .

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,12 @@
+name: CI
+
+on: pull_request
+
+jobs:
+  hub-build-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - id: tests
+        run: ./scripts/tests.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
-FROM jinaai/jina:2.0.3
+FROM jinaai/jina:2.0.8-perf
 
 # install git
-RUN apt-get -y update && apt-get install -y git
+RUN apt-get -y update && apt-get install -y git \
+    && rm -rf /var/lib/apt/lists/*
 
 # install requirements before copying the workspace
 COPY requirements.txt /requirements.txt
-RUN pip install -r requirements.txt
+RUN pip install -r requirements.txt --no-cache-dir
 
 # setup the workspace
 COPY . /workspace

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jinaai/jina:2.0.8-perf
+FROM jinaai/jina:2.0.10-perf
 
 # install git
 RUN apt-get -y update && apt-get install -y git \

--- a/README.md
+++ b/README.md
@@ -1,12 +1,8 @@
-<p align="center">
-<img src="https://github.com/jina-ai/jina/blob/master/.github/logo-only.gif?raw=true" alt="Jina banner" width="200px">
-</p>
-
-# CLIPTextEncoder
+# ✨ CLIPTextEncoder
 
  **CLIPTextEncoder** is a class that wraps the text embedding functionality from the **CLIP** model.
 
-The **CLIP** model was originally proposed in  [Learning Transferable Visual Models From Natural Language Supervision](https://cdn.openai.com/papers/Learning_Transferable_Visual_Models_From_Natural_Language_Supervision.pdf).
+The **CLIP** model was originally proposed in  [Learning Transferable Visual Models From Natural Language Supervision](https://arxiv.org/abs/2103.00020).
 
 `CLIPTextEncoder` encodes data from a `np.ndarray` of strings and returns a `np.ndarray` of floating point values.
 
@@ -14,34 +10,24 @@ The **CLIP** model was originally proposed in  [Learning Transferable Visual Mod
 
 - Output shape: `BatchSize x EmbeddingDimension`
 
-## Prerequisites
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**
 
-To install the dependencies locally run 
-```
-pip install . 
-pip install -r tests/requirements.txt
-```
-To verify the installation works:
-```
-pytest tests
-```
+- [🌱 Prerequisites](#-prerequisites)
+- [🚀 Usages](#-usages)
+- [🎉️ Example](#%EF%B8%8F-example)
+- [🔍️ Reference](#%EF%B8%8F-reference)
 
-## Encode with the encoder:
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-The following example shows how to generate output embeddings given an input `np.ndarray` of strings.
+## 🌱 Prerequisites
 
-```python
-# Input data
-text_batch = np.array(['Han likes eating pizza', 'Han likes pizza', 'Jina rocks'])
+No prerequisites are required to run this executor.
 
-# Encoder embedding 
-encoder = CLIPTextEncoder()
-embeddeding_batch_np = encoder.encode(text_batch)
+## 🚀 Usages
 
-
-## Usages
-
-### Via JinaHub (🚧W.I.P.)
+### 🚚 Via JinaHub (🚧 WIP)
 
 Use the prebuilt images from JinaHub in your python codes, 
 
@@ -50,7 +36,8 @@ from jina import Flow
 	
 f = Flow().add(
         uses='jinahub+docker://CLIPTextEncoder',
-        volumes='/your_home_folder/.cache/clip:/root/.cache/clip')
+        volumes='/your_home_folder/.cache/clip:/root/.cache/clip'
+	)
 ```
 
 or in the `.yml` config.
@@ -64,7 +51,7 @@ pods:
 ```
 
 
-### Via Pypi
+### 📦️ Via Pypi
 
 1. Install the `jinahub-text-clip-text-encoder`
 
@@ -82,7 +69,7 @@ pods:
 	```
 
 
-### Via Docker
+### 🐳 Via Docker
 
 1. Clone the repo and build the docker image
 
@@ -92,19 +79,20 @@ pods:
 	docker build -t jinahub-clip-text .
 	```
 
-1. Use `jinahub-clip-text` in your codes
+2. Use `jinahub-clip-text` in your code
 
 	```python
 	from jina import Flow
 	
 	f = Flow().add(
 	        uses='docker://jinahub-clip-text:latest',
-	        volumes='/your_home_folder/.cache/clip:/root/.cache/clip')
+	        volumes='/your_home_folder/.cache/clip:/root/.cache/clip'
+		)
 	```
 	
 
 
-## Example 
+## 🎉️ Example 
 
 
 ```python
@@ -113,7 +101,8 @@ import numpy as np
 	
 f = Flow().add(
         uses='jinahub+docker://CLIPTextEncoder',
-        volumes='/your_home_folder/.cache/clip:/root/.cache/clip')
+        volumes='/your_home_folder/.cache/clip:/root/.cache/clip'
+	)
 	
 def check_emb(resp):
     for doc in resp.data.docs:
@@ -124,7 +113,8 @@ with f:
 	f.post(
 	    on='/foo', 
 	    inputs=Document(text='your text'), 
-	    on_done=check_emb)
+	    on_done=check_emb
+	)
 	    
 ```
 
@@ -139,6 +129,8 @@ with f:
 
 
 
-## Reference
-- https://cdn.openai.com/papers/Learning_Transferable_Visual_Models_From_Natural_Language_Supervision.pdf
-- https://github.com/openai/CLIP
+## 🔍️ Reference
+
+- [CLIP blog post](https://openai.com/blog/clip/)
+- [CLIP paper](https://arxiv.org/abs/2103.00020)
+- [CLIP GitHub repository](https://github.com/openai/CLIP)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ No prerequisites are required to run this executor.
 
 ## 🚀 Usages
 
-### 🚚 Via JinaHub (🚧 WIP)
+### 🚚 Via JinaHub
 
 Use the prebuilt images from JinaHub in your python codes, 
 

--- a/clip_text.py
+++ b/clip_text.py
@@ -22,7 +22,7 @@ class CLIPTextEncoder(Executor):
         self,
         model_name: str = 'ViT-B/32',
         default_batch_size: int = 32,
-        default_traversal_paths: Optional[List[str]] = None,
+        default_traversal_paths: List[str] = ['r'],
         default_device: str = 'cpu',
         jit: bool = True,
         *args,
@@ -31,7 +31,7 @@ class CLIPTextEncoder(Executor):
         super().__init__(*args, **kwargs)
         self.device = default_device
         self.model, _ = clip.load(model_name, self.device, jit)
-        self.default_traversal_paths = default_traversal_paths or ['r']
+        self.default_traversal_paths = default_traversal_paths
         self.default_batch_size = default_batch_size
 
     @requests

--- a/clip_text.py
+++ b/clip_text.py
@@ -6,35 +6,53 @@ from jina_commons.batching import get_docs_batch_generator
 
 
 class CLIPTextEncoder(Executor):
-    """Encode text into embeddings."""
+    """Encode text into embeddings using a CLIP model.
 
-    def __init__(self,
-                 model_name: str = 'ViT-B/32',
-                 default_batch_size: int = 32,
-                 default_traversal_paths: Optional[List[str]] = None,
-                 default_device: Optional[str] = 'cpu',
-                 jit: bool = True,
-                 *args, **kwargs):
+    :param model_name: The name of one of the pre-trained CLIP models.
+        Can also be a path to a local checkpoint (a ``.pt`` file).
+    :param default_batch_size: Default batch size for encoding, used if the
+        batch size is not passed as a parameter with the request.
+    :param default_traversal_paths: Default traversal paths for encoding, used if the
+        traversal path is not passed as a parameter with the request.
+    :param default_device: The device (cpu or gpu) that the model should be on.
+    :param jit: Whether a JIT version of the model should be loaded.
+    """
+
+    def __init__(
+        self,
+        model_name: str = 'ViT-B/32',
+        default_batch_size: int = 32,
+        default_traversal_paths: Optional[List[str]] = None,
+        default_device: str = 'cpu',
+        jit: bool = True,
+        *args,
+        **kwargs
+    ):
         super().__init__(*args, **kwargs)
-        self.device = default_device or 'cpu'
+        self.device = default_device
         self.model, _ = clip.load(model_name, self.device, jit)
         self.default_traversal_paths = default_traversal_paths or ['r']
         self.default_batch_size = default_batch_size
 
     @requests
-    def encode(self, docs: Optional[DocumentArray], parameters: dict, **kwargs):
+    def encode(
+        self, docs: Optional[DocumentArray] = None, parameters: dict = {}, **kwargs
+    ):
         """
-        Encode all docs with text and store the encodings in the embedding attribute of the docs.
+        Encode all docs with text and store the encodings in the embedding 
+        attribute of the docs.
+
         :param docs: documents sent to the encoder. The docs must have text.
-        :param parameters: dictionary to define the `traversal_path` and the `batch_size`.
-            For example,
-            `parameters={'traversal_paths': ['r'], 'batch_size': 10}`
-            will set the parameters for traversal_paths, batch_size and that are actually used
+        :param parameters: dictionary to define the ``traversal_path`` and the 
+            ``batch_size``. For example, 
+            ``parameters={'traversal_paths': ['r'], 'batch_size': 10}``
         """
         if docs:
             document_batches_generator = get_docs_batch_generator(
                 docs,
-                traversal_path=parameters.get('traversal_paths', self.default_traversal_paths),
+                traversal_path=parameters.get(
+                    'traversal_paths', self.default_traversal_paths
+                ),
                 batch_size=parameters.get('batch_size', self.default_batch_size),
                 needs_attr='text',
             )
@@ -44,9 +62,10 @@ class CLIPTextEncoder(Executor):
         with torch.no_grad():
             for document_batch in document_batches_generator:
                 text_batch = [d.text for d in document_batch]
-                tensor = clip.tokenize(text_batch)
-                tensor = tensor.to(self.device)
+                tensor = clip.tokenize(text_batch).to(self.device)
                 embedding_batch = self.model.encode_text(tensor)
                 numpy_embedding_batch = embedding_batch.cpu().numpy()
-                for document, numpy_embedding in zip(document_batch, numpy_embedding_batch):
+                for document, numpy_embedding in zip(
+                    document_batch, numpy_embedding_batch
+                ):
                     document.embedding = numpy_embedding

--- a/clip_text.py
+++ b/clip_text.py
@@ -35,9 +35,7 @@ class CLIPTextEncoder(Executor):
         self.default_batch_size = default_batch_size
 
     @requests
-    def encode(
-        self, docs: Optional[DocumentArray] = None, parameters: dict = {}, **kwargs
-    ):
+    def encode(self, docs: Optional[DocumentArray], parameters: dict, **kwargs):
         """
         Encode all docs with text and store the encodings in the embedding
         attribute of the docs.

--- a/clip_text.py
+++ b/clip_text.py
@@ -39,12 +39,12 @@ class CLIPTextEncoder(Executor):
         self, docs: Optional[DocumentArray] = None, parameters: dict = {}, **kwargs
     ):
         """
-        Encode all docs with text and store the encodings in the embedding 
+        Encode all docs with text and store the encodings in the embedding
         attribute of the docs.
 
         :param docs: documents sent to the encoder. The docs must have text.
-        :param parameters: dictionary to define the ``traversal_path`` and the 
-            ``batch_size``. For example, 
+        :param parameters: dictionary to define the ``traversal_path`` and the
+            ``batch_size``. For example,
             ``parameters={'traversal_paths': ['r'], 'batch_size': 10}``
         """
         if docs:

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,5 +1,5 @@
 manifest_version: 1
-name: CLIP Text Encoder
+name: CLIPTextEncoder
 alias: CLIPTextEncoder
 description: Encoder based on the CLIP model
 author: Jina AI Dev-Team (dev-team@jina.ai)

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,8 +1,8 @@
 manifest_version: 1
-name: CLIPTextEncoder
+name: CLIP Text Encoder
 alias: CLIPTextEncoder
-description: Encoder based on the Clip model proposed in https://cdn.openai.com/papers/Learning_Transferable_Visual_Models_From_Natural_Language_Supervision.pdf
+description: Encoder based on the CLIP model
 author: Jina AI Dev-Team (dev-team@jina.ai)
-url: https://jina.ai
+url: https://github.com/jina-ai/executor-text-clip-text-encoder
 avatar: https://avatars.githubusercontent.com/u/60539444?s=200&v=4
 keywords: [clip, text, crossmodal, encoder, PyTorch, en]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 torch==1.7.1
 clip @ git+https://github.com/openai/CLIP.git@cfcffb90e69f37bf2ff1e988237a0fbe41f33c04
-jina==2.0.8
+jina==2.0.10
 jina-commons @ git+https://github.com/jina-ai/jina-commons.git@v0.0.1#egg=jina-commons

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 torch==1.7.1
 clip @ git+https://github.com/openai/CLIP.git@cfcffb90e69f37bf2ff1e988237a0fbe41f33c04
-jina-commons @ git+https://github.com/jina-ai/jina-commons.git#egg=jina-commons
+jina==2.0.8
+jina-commons @ git+https://github.com/jina-ai/jina-commons.git@v0.0.1#egg=jina-commons

--- a/setup.py
+++ b/setup.py
@@ -2,18 +2,18 @@ import setuptools
 
 
 setuptools.setup(
-    name="jinahub-clip-text",
-    version="2.0",
+    name='jinahub-clip-text',
+    version='2.0',
     author='Jina Dev Team',
     author_email='dev-team@jina.ai',
-    description="Executor that encodes text with CLIP model",
-    url="https://github.com/jina-ai/executor-text-clip-text-encoder",
+    description='Executor that encodes text with CLIP model',
+    url='https://github.com/jina-ai/executor-text-clip-text-encoder',
     classifiers=[
-        "Programming Language :: Python :: 3",
-        "Operating System :: OS Independent",
+        'Programming Language :: Python :: 3',
+        'Operating System :: OS Independent',
     ],
     py_modules=['jinahub.encoder.clip_text'],
     package_dir={'jinahub.encoder': '.'},
-    install_requires=open("requirements.txt").readlines(),
-    python_requires=">=3.7",
+    install_requires=open('requirements.txt').readlines(),
+    python_requires='>=3.7',
 )

--- a/tests/integration/test_with_flow.py
+++ b/tests/integration/test_with_flow.py
@@ -15,30 +15,52 @@ def test_fail():
 def test_traversal_path():
     text = 'blah'
     docs = [Document(id='root1', text=text)]
-    docs[0].chunks = [Document(id='chunk11', text=text),
-                      Document(id='chunk12', text=text),
-                      Document(id='chunk13', text=text)
-                      ]
+    docs[0].chunks = [
+        Document(id='chunk11', text=text),
+        Document(id='chunk12', text=text),
+        Document(id='chunk13', text=text),
+    ]
     docs[0].chunks[0].chunks = [
         Document(id='chunk111', text=text),
         Document(id='chunk112', text=text),
     ]
 
-    f = Flow().add(uses={
-        'jtype': CLIPTextEncoder.__name__,
-        'with': {
-            'default_traversal_paths': ['c'],
-            'model_name': 'ViT-B/32',
+    f = Flow().add(
+        uses={
+            'jtype': CLIPTextEncoder.__name__,
+            'with': {
+                'default_traversal_paths': ['c'],
+                'model_name': 'ViT-B/32',
+            },
         }
-    })
+    )
     with f:
         result = f.post(on='/test', inputs=docs, return_results=True)
         for path, count in [['r', 0], ['c', 3], ['cc', 0]]:
-            assert len(DocumentArray(result[0].data.docs).traverse_flat([path]).get_attributes('embedding')) == count
+            assert (
+                len(
+                    DocumentArray(result[0].data.docs)
+                    .traverse_flat([path])
+                    .get_attributes('embedding')
+                )
+                == count
+            )
 
-        result = f.post(on='/test', inputs=docs, parameters={'traversal_paths': ['cc']}, return_results=True)
+        result = f.post(
+            on='/test',
+            inputs=docs,
+            parameters={'traversal_paths': ['cc']},
+            return_results=True,
+        )
         for path, count in [['r', 0], ['c', 0], ['cc', 2]]:
-            assert len(DocumentArray(result[0].data.docs).traverse_flat([path]).get_attributes('embedding')) == count
+            assert (
+                len(
+                    DocumentArray(result[0].data.docs)
+                    .traverse_flat([path])
+                    .get_attributes('embedding')
+                )
+                == count
+            )
 
 
 def test_no_documents():

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,4 @@
 torch==1.7.1
 clip @ git+https://github.com/openai/CLIP.git@cfcffb90e69f37bf2ff1e988237a0fbe41f33c04
 pytest==6.2.4
-jina[hub]==2.0.8
+jina[hub]==2.0.10

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,4 @@
 torch==1.7.1
 clip @ git+https://github.com/openai/CLIP.git@cfcffb90e69f37bf2ff1e988237a0fbe41f33c04
 pytest==6.2.4
-git+https://github.com/jina-ai/jina.git@v2.0.3#egg=jina[hub]
+jina[hub]==2.0.8

--- a/tests/unit/test_clip_text.py
+++ b/tests/unit/test_clip_text.py
@@ -26,8 +26,13 @@ def test_clip_data():
     for word in words:
         docs.append(Document(text=word))
 
-    sentences = ['Jina AI is lit', 'Jina AI is great', 'Jina AI is a cloud-native neural search company', \
-                 'Jina AI is a github repo', 'Jina AI is an open source neural search project']
+    sentences = [
+        'Jina AI is lit',
+        'Jina AI is great',
+        'Jina AI is a cloud-native neural search company',
+        'Jina AI is a github repo',
+        'Jina AI is an open source neural search project',
+    ]
     for sentence in sentences:
         docs.append(Document(text=sentence))
 
@@ -51,9 +56,13 @@ def test_clip_data():
     assert small_distance < dist('banana1', 'studio')
     assert small_distance < dist('banana2', 'airplane')
     small_distance = dist('Jina AI is lit', 'Jina AI is great')
-    assert small_distance < dist('Jina AI is a cloud-native neural search company', 'Jina AI is a github repo')
-    assert small_distance < dist('Jina AI is a cloud-native neural search company',
-                                 'Jina AI is an open source neural search project')
+    assert small_distance < dist(
+        'Jina AI is a cloud-native neural search company', 'Jina AI is a github repo'
+    )
+    assert small_distance < dist(
+        'Jina AI is a cloud-native neural search company',
+        'Jina AI is an open source neural search project',
+    )
 
     # assert same results like calculating it manually
     model, preprocess = clip.load('ViT-B/32', device='cpu')

--- a/tests/unit/test_clip_text.py
+++ b/tests/unit/test_clip_text.py
@@ -8,7 +8,7 @@ from jinahub.encoder.clip_text import CLIPTextEncoder
 def test_no_documents():
     clip_text_encoder = CLIPTextEncoder()
     test_docs = DocumentArray()
-    clip_text_encoder.encode(test_docs)
+    clip_text_encoder.encode(test_docs, parameters={})
     assert len(test_docs) == 0  # SUCCESS
 
 


### PR DESCRIPTION
This is mainly a refactor of the current code, no real changes. Things done:
- add CI/CD
- make sure that the structure and content conforms to the [template](https://github.com/jina-ai/executor-template)
- format all python code with black
- small fix: add empty dict as `parameters` in unit test (otherwise test breaks)